### PR TITLE
Password Change Feature File

### DIFF
--- a/src/test/resources/tests/PasswordChange.feature
+++ b/src/test/resources/tests/PasswordChange.feature
@@ -3,4 +3,41 @@ Feature: The user can change their own password
   I want to be able to change my own password within the guidelines of password policy
   So that the integrity of my account security requirements are met.
 
-    Scenario:
+    Background:
+      Given User exists for Username "Alex20" with Password "ABC123"
+      And Username set to "Alex20"
+      And Password set to "ABC123"
+
+    Scenario: Valid password change facilitated
+      When new password set to "DEF456"
+      And verify password set to "DEF456"
+      And change submitted
+      Then response is "Password changed successfully"
+
+    Scenario: New password not entered
+      When change submitted
+      Then response is "Please enter a new password"
+
+    Scenario: Mismatched new password
+      When new password set to "DEF456"
+      And verify password set to "DEF555"
+      And change submitted
+      Then response is "New passwords do not match"
+
+    Scenario: New password contains no digits
+      When new password set to "DEF"
+      And verify password set to "DEF"
+      And change submitted
+      Then response is "Password must contain at least 1 digit"
+
+    Scenario: New password is too short
+      When new password set to "D2"
+      And verify password set to "D2"
+      And change submitted
+      Then response is "Password must contain at least 3 characters"
+
+    Scenario: Password change cancelled
+      When new password set to "DEF456"
+      And verify password set to "DEF456"
+      And change cancelled
+      Then response is "Password change cancelled"

--- a/src/test/resources/tests/PasswordChange.feature
+++ b/src/test/resources/tests/PasswordChange.feature
@@ -5,39 +5,65 @@ Feature: The user can change their own password
 
     Background:
       Given User exists for Username "Alex20" with Password "ABC123"
-      And Username set to "Alex20"
-      And Password set to "ABC123"
 
     Scenario: Valid password change facilitated
-      When new password set to "DEF456"
+      When Username set to "Alex20"
+      And Password set to "ABC123"
+      And new password set to "DEF456"
       And verify password set to "DEF456"
       And change submitted
       Then response is "Password changed successfully"
 
     Scenario: New password not entered
+      When Username set to "Alex20"
+      And Password set to "ABC123"
       When change submitted
       Then response is "Please enter a new password"
 
     Scenario: Mismatched new password
-      When new password set to "DEF456"
+      When Username set to "Alex20"
+      And Password set to "ABC123"
+      And new password set to "DEF456"
       And verify password set to "DEF555"
       And change submitted
       Then response is "New passwords do not match"
 
     Scenario: New password contains no digits
-      When new password set to "DEF"
+      When Username set to "Alex20"
+      And Password set to "ABC123"
+      And new password set to "DEF"
       And verify password set to "DEF"
       And change submitted
       Then response is "Password must contain at least 1 digit"
 
     Scenario: New password is too short
-      When new password set to "D2"
+      When Username set to "Alex20"
+      And Password set to "ABC123"
+      And new password set to "D2"
       And verify password set to "D2"
       And change submitted
       Then response is "Password must contain at least 3 characters"
 
     Scenario: Password change cancelled
-      When new password set to "DEF456"
+      When Username set to "Alex20"
+      And Password set to "ABC123"
+      And new password set to "DEF456"
       And verify password set to "DEF456"
       And change cancelled
       Then response is "Password change cancelled"
+    
+    Scenario: User does not exist
+      When Username set to "Sarah3"
+      And Password set to "ABC123"
+      And new password set to "DEF456"
+      And verify password set to "DEF456"
+      And change cancelled
+      Then response is "No user with that username exists"
+    
+    Scenario: Given password does not match account password
+      When Username set to "Alex20"
+      And Password set to "ABC345"
+      And new password set to "DEF456"
+      And verify password set to "DEF456"
+      And change cancelled
+      Then response is "Current password is incorrect"


### PR DESCRIPTION
Added some test cases one would expect
Doesn't cover a few cases, since the Given clause was written to reduce redundancy:
- When a user doesn't exist
- When the user's given current password does not match their account's actual password